### PR TITLE
Register RequireJS configuration without hook

### DIFF
--- a/Classes/Hook/PageRendererRenderPreProcess.php
+++ b/Classes/Hook/PageRendererRenderPreProcess.php
@@ -12,20 +12,10 @@ final class PageRendererRenderPreProcess
 {
     public function addRequireJsConfiguration(array $params, PageRenderer $pageRenderer): void
     {
+        //\TYPO3\CMS\Extbase\Utility\DebuggerUtility::var_dump($params, 'test');
         if (($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface
             && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isBackend()
         ) {
-            $pageRenderer->addRequireJsConfiguration([
-                'shim' => [
-                    'trianglify' => ['exports' => 'trianglify']
-                ],
-                'paths' => [
-                    'trianglify' => \TYPO3\CMS\Core\Utility\PathUtility::getAbsoluteWebPath(
-                            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('trianglify',
-                                'Resources/Public/JavaScript/')
-                        ) . 'trianglify.bundle'
-                ]
-            ]);
             $pageRenderer->loadRequireJsModule('TYPO3/CMS/Trianglify/TrianglifyBackground');
         }
     }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,7 +3,10 @@
 if ($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['backend']['loginBackgroundImage'] == '') {
     $loadTrianglifyBackground = false;
     $typo3Version = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Information\Typo3Version::class);
-    if ($typo3Version->getMajorVersion() === 10 && (TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_BE)) {
+
+    if ($typo3Version->getMajorVersion() === 11 ||
+        ($typo3Version->getMajorVersion() === 10 && (TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_BE))) {
+
         $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
         $pageRenderer->addRequireJsConfiguration([
             'shim' => [
@@ -16,8 +19,12 @@ if ($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['backend']['loginBackgroundImage']
                     ) . 'trianglify.bundle'
             ]
         ]);
+    }
+
+    if ($typo3Version->getMajorVersion() === 10 && (TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_BE)) {
         $pageRenderer->loadRequireJsModule('TYPO3/CMS/Trianglify/TrianglifyBackground');
     }
+
     if ($typo3Version->getMajorVersion() === 11) {
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess'][] =
             \K10\Trianglify\Hook\PageRendererRenderPreProcess::class . '->addRequireJsConfiguration';


### PR DESCRIPTION
The hook is not executed when RequireJS configuration is loaded ondemand in the login screen

This depends on https://review.typo3.org/c/Packages/TYPO3.CMS/+/71395